### PR TITLE
feat(*): Add disable_checkout_action input

### DIFF
--- a/.github/workflows/add-on-disable-checkout-test.yml
+++ b/.github/workflows/add-on-disable-checkout-test.yml
@@ -1,4 +1,4 @@
-name: Add-on multiple tests
+name: Add-on with disabled checkout tests
 on:
   push:
     branches:
@@ -6,7 +6,7 @@ on:
     paths-ignore:
       - '**.md'
   schedule:
-    - cron: '25 09 * * *'
+    - cron: '35 08 * * *'
   workflow_dispatch:
 
 permissions:
@@ -19,9 +19,9 @@ jobs:
       fail-fast: false
       matrix:
         ddev_version: [ stable ]
-        add_on: ["ddev/ddev-redis-commander", "ddev/ddev-mongo", "ddev/ddev-adminer"]
+        add_on: ["JanoPL/ddev-kibana"]
 
-    name: Add-on multiple tests
+    name: Add-on simple tests
     runs-on: ubuntu-latest
 
     steps:
@@ -32,6 +32,15 @@ jobs:
       - name: Retrieve last tag of add-on
         run: |
           echo "ADD_ON_LAST_TAG=$(curl -Ls -o /dev/null -w %{url_effective} https://github.com/${{ matrix.add_on }}/releases/latest | grep -oP "\/tag\/\K(.*)$")" >> $GITHUB_ENV 
+          
+          
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ matrix.add_on }}
+          ref: ${{ env.ADD_ON_LAST_TAG }}
+          path: tested-addon
+          submodules: 'true'
 
       - name: Run DDEV test (${{ matrix.ddev_version }})
         uses: ./
@@ -42,3 +51,5 @@ jobs:
           addon_ref: ${{ env.ADD_ON_LAST_TAG }}
           addon_path: tested-addon
           keepalive: false
+          disable_checkout_action: true
+

--- a/.github/workflows/add-on-disable-checkout-test.yml
+++ b/.github/workflows/add-on-disable-checkout-test.yml
@@ -14,14 +14,14 @@ permissions:
 
 
 jobs:
-  add-on-simple-test:
+  add-on-disable-checkout-test:
     strategy:
       fail-fast: false
       matrix:
         ddev_version: [ stable ]
         add_on: ["JanoPL/ddev-kibana"]
 
-    name: Add-on simple tests
+    name: Add-on with disabled checkout tests
     runs-on: ubuntu-latest
 
     steps:
@@ -32,8 +32,7 @@ jobs:
       - name: Retrieve last tag of add-on
         run: |
           echo "ADD_ON_LAST_TAG=$(curl -Ls -o /dev/null -w %{url_effective} https://github.com/${{ matrix.add_on }}/releases/latest | grep -oP "\/tag\/\K(.*)$")" >> $GITHUB_ENV 
-          
-          
+
       - name: Checkout
         uses: actions/checkout@v3
         with:

--- a/README.md
+++ b/README.md
@@ -144,6 +144,16 @@ Default: `false`.
 
 ---
 
+- `disable_checkout_action` (_Boolean_)
+
+If you need to check out your add-on source code with some specific inputs (`submodules`, `ssh-key`, etc.), or you need to perform some extra steps between checkout and DDEV installation steps, you can disable the default checkout action by setting `true` for this input.
+
+Not required.
+
+Default: `false`.
+
+---
+
 ## Usage
 
 ### Test your DDEV add-on

--- a/action.yaml
+++ b/action.yaml
@@ -43,6 +43,12 @@ inputs:
     required: false
     default: false
 
+  disable_checkout_action:
+    type: boolean
+    description: Disable addon checkout action
+    required: false
+    default: false
+
   token:
     description: 'A Github PAT'
     required: true
@@ -60,6 +66,7 @@ runs:
         mkcert -install
 
     - uses: actions/checkout@v3
+      if: inputs.disable_checkout_action == 'false'
       with:
         repository: ${{ inputs.addon_repository }}
         ref: ${{ inputs.addon_ref }}


### PR DESCRIPTION
## The Issue

Some add-on may need specific input for the add-on checkout action. Or some extra step between the checkout action and the DDEV install.

## How This PR Solves The Issue

This PR add the possibility of disabling the default checkout action so the add-on test can use its own checkout action.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

https://github.com/ddev/github-action-add-on-test/issues/9

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

