### PR TITLE
fix: tag name needs description

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - main
     inputs:
       tag_name:
+        description: Tag name
         type: string
         required: true
       first-release:


### PR DESCRIPTION
## The Issue

I happened to note looking at yamls in IDE that the `description` attribute for tag_name was missing, so it wouldn't validate.

