### PR TITLE
feat: add bats assertion capability

### DIFF
--- a/.github/workflows/single-add-on-test.yml
+++ b/.github/workflows/single-add-on-test.yml
@@ -25,14 +25,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up Homebrew
-        id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@master
-      - name: Environment setup
-        run: |
-          # For bats-assert and friends
-          brew tap kaos/shell
-          brew install bats-core bats-assert bats-support jq mkcert yq
+
       - name: Clone current repository
         uses: actions/checkout@v3
 

--- a/.github/workflows/single-add-on-test.yml
+++ b/.github/workflows/single-add-on-test.yml
@@ -25,7 +25,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-
+      - name: Set up Homebrew
+        id: set-up-homebrew
+        uses: Homebrew/actions/setup-homebrew@master
+      - name: Environment setup
+        run: |
+          # For bats-assert and friends
+          brew tap kaos/shell
+          brew install bats-core bats-assert bats-support jq mkcert yq
       - name: Clone current repository
         uses: actions/checkout@v3
 

--- a/action.yaml
+++ b/action.yaml
@@ -62,7 +62,9 @@ runs:
     - name: Environment setup
       shell: bash
       run: |
-        brew install bats-core mkcert
+        # For bats-assert and friends
+        brew tap kaos/shell
+        brew install bats-core bats-assert bats-support jq mkcert yq
         mkcert -install
 
     - uses: actions/checkout@v3


### PR DESCRIPTION
## The Issue

Over in 
* https://github.com/ddev/github-action-add-on-test/issues/9#issuecomment-1685328045

@JanoPL mentioned that he was using submodules specifically to install bats-assert.

But bats-assert and friends are so very useful and important, they should be used more, and it seems like we should just install them by default.

## How This PR Solves The Issue

Install them. 

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

