### PR TITLE
fix(bats): Add bats-file

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -64,7 +64,7 @@ runs:
       run: |
         # For bats-assert and friends
         brew tap kaos/shell
-        brew install bats-core bats-assert bats-support jq mkcert yq
+        brew install bats-file bats-assert bats-support jq mkcert yq
         mkcert -install
 
     - uses: actions/checkout@v3

--- a/action.yaml
+++ b/action.yaml
@@ -64,7 +64,7 @@ runs:
       run: |
         # For bats-assert and friends
         brew tap kaos/shell
-        brew install bats-file bats-assert bats-support jq mkcert yq
+        brew install bats-core bats-file bats-assert bats-support jq mkcert yq
         mkcert -install
 
     - uses: actions/checkout@v3


### PR DESCRIPTION
## The Issue

"bats-file" helper was not installed.

And "bats-core" has been renamed in "bats-support" (see [here](https://github.com/ztombol/bats-support) ), so it is unnecessary to "brew install" it: 
> Important: bats-core has been renamed to bats-support. GitHub automatically redirects all references, e.g. submodules and clones will continue to work, but you are encouraged to [update](https://help.github.com/articles/renaming-a-repository/) them. Version numbering continues where bats-core left off. 

## How This PR Solves The Issue

Install "bats-file" and remove "bats-core" install

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

