### PR TITLE
ci(disable checkout test): update addon on ref release version

### DIFF
--- a/.github/workflows/add-on-disable-checkout-test.yml
+++ b/.github/workflows/add-on-disable-checkout-test.yml
@@ -22,14 +22,19 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       ADD_ON: JanoPL/ddev-kibana
-      ADD_ON_REF: v1.5.1
+      ADD_ON_REF: ""
       DDEV_VERSION: stable
 
     steps:
 
       - name: Clone current repository
         uses: actions/checkout@v3
+
+      - name: Retrieve last tag of add-on
+        run: |
+          echo "ADD_ON_REF=$(gh api https://api.github.com/repos/JanoPL/ddev-kibana/releases/latest | jq '.tag_name')" >> $GITHUB_ENV
 
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## The Issue

Every time the addon gets a version, the workflow needs to be changed and modified manually.

## How This PR Solves The Issue

Get the latest release from the GH API, from where we extract the new tag name

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

