### PR TITLE
fix: turn off instrumentation for ddev tests

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -95,9 +95,14 @@ runs:
       if: inputs.debug_enabled == 'true'
 
     - name: Run test
-      # Allow ddev get to use a GitHub token to prevent rate limiting by tests
       env:
+        # Allow ddev get to use a GitHub token to prevent rate limiting by tests
         DDEV_GITHUB_TOKEN: ${{ inputs.token }}
+        # Don't try interactive behaviors
+        DDEV_NONINTERACTIVE: "true"
+        # Don't send telemetry to amplitude
+        DDEV_NO_INSTRUMENTATION: "true"
+
       shell: bash
       run: cd ${{ inputs.addon_path }} && bats tests
 


### PR DESCRIPTION
## The Issue

Instrumentation/telemetry should not be turned on for tests. It also results in unwanted output on HEAD, see 
* https://github.com/ddev/ddev-platformsh/pull/118

## How This PR Solves The Issue

Add the environment variable to turn it off.

