### PR TITLE
fix(node16): Use action/checkout v4 as Node 16 is deprecated

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -67,7 +67,7 @@ runs:
         brew install bats-core bats-file bats-assert bats-support jq mkcert yq
         mkcert -install
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       if: inputs.disable_checkout_action == 'false'
       with:
         repository: ${{ inputs.addon_repository }}


### PR DESCRIPTION
## The Issue

There are warning messages (complaining about Node 16 deprecation) when using this action.
![Capture d’écran du 2024-02-11 16-25-43](https://github.com/ddev/github-action-add-on-test/assets/20956510/e2a34096-83c2-4396-8c67-14450b9aacdc)


## How This PR Solves The Issue

We are updating action/checkout from v3 to v4.

For the Homebrew action, we should just wait for their update: 

https://github.com/Homebrew/actions/issues/484

That's why I'm creating this PR as a draft and will change it to "ready for review" when the Homebrew update is available.


## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

