### PR TITLE
feat(keepalive): Use keepalive-workflow@v2 to avoid dummy commit

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -15,9 +15,7 @@ jobs:
       - name: Clone project files
         uses: actions/checkout@v4
 
-      # keepalive-workflow adds a dummy commit if there's no other action here, keeps
-      # GitHub from turning off tests after 60 days
-      - uses: gautamkrishnar/keepalive-workflow@v1
+      # keepalive-workflow keeps GitHub from turning off tests after 60 days
+      - uses: gautamkrishnar/keepalive-workflow@v2
         with:
-          commit_message: "chore(*): Automated commit to keep the repository active"
           time_elapsed: 50

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ The [public API](https://semver.org/spec/v2.0.0.html#spec-item-1) of this projec
 
 ---
 
+## [v2.0.0](https://github.com/ddev/github-action-add-on-test/releases/tag/v2.0.0) - 2024-03-??
+
+[_Compare with previous release_](https://github.com/ddev/github-action-add-on-test/compare/v1.2.0...v2.0.0)
+
+### Changed
+
+- **Breaking change**: Use `gautamkrishnar/keepalive-workflow@v2` to avoid dummy commit. This change requires 
+  modifying permission from `content: write` to `actions: write` in the main workflow.
+
+---
+
 ## [v1.2.0](https://github.com/ddev/github-action-add-on-test/releases/tag/v1.2.0) - 2024-02-19
 
 [_Compare with previous release_](https://github.com/ddev/github-action-add-on-test/compare/v1.1.1...v1.2.0)

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ If enabled, action will use [keepalive-workflow action](https://github.com/gauta
 
 ```yaml
 permissions:
-  contents: write
+  actions: write
 ```
 
 Not required.
@@ -188,7 +188,7 @@ on:
         default: false
 
 permissions:
-  contents: write
+  actions: write
 
 jobs:
   tests:
@@ -202,7 +202,7 @@ jobs:
 
     steps:
 
-    - uses: ddev/github-action-add-on-test@v1
+    - uses: ddev/github-action-add-on-test@v2
       with:
         ddev_version: ${{ matrix.ddev_version }}
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/action.yaml
+++ b/action.yaml
@@ -106,12 +106,10 @@ runs:
       shell: bash
       run: cd ${{ inputs.addon_path }} && bats tests
 
-    # keepalive-workflow adds a dummy commit if there's no other action here, keeps
-    # GitHub from turning off tests after 60 days
-    - uses: gautamkrishnar/keepalive-workflow@v1
+    # keepalive-workflow keeps GitHub from turning off tests after 60 days
+    - uses: gautamkrishnar/keepalive-workflow@v2
       if: always() && matrix.ddev_version == 'stable' && inputs.keepalive == 'true'
       with:
-        commit_message: "chore(*): Automated commit to keep the repository active"
         time_elapsed: ${{ inputs.keepalive_time_elapsed }}
 
 branding:


### PR DESCRIPTION
## The Issue

Fixes #27

## How This PR Solves The Issue

Uses gautamkrishnar/keepalive-workflow@v2

## Manual Testing Instructions

Untestable ( ? ).

On a personal project, I've tried the action with `time_elapsed` = 0 and the only thing we can see is a message we have to believe
 : `Kept repo active using the GitHub API ...` : 

![Capture d’écran du 2024-03-14 17-51-29](https://github.com/ddev/github-action-add-on-test/assets/20956510/dd41a2eb-42e0-4b06-9dd6-190a16cbb3c7)



## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

