### PR TITLE
fix: Shorten the time before API call

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -33,9 +33,9 @@ inputs:
     default: true
 
   keepalive_time_elapsed:
-    description: 'Time elapsed from the previous commit to trigger a new automated commit (in days)'
+    description: 'Time elapsed from the most recent commit to hit API and prevent expiration (in days)'
     required: false
-    default: 55
+    default: 45
 
   debug_enabled:
     type: boolean

--- a/action.yaml
+++ b/action.yaml
@@ -35,7 +35,7 @@ inputs:
   keepalive_time_elapsed:
     description: 'Time elapsed from the most recent commit to hit API and prevent expiration (in days)'
     required: false
-    default: 45
+    default: "0"
 
   debug_enabled:
     type: boolean


### PR DESCRIPTION
The current 55 day timeout before we hit the API seems to be a little long, as GitHub warns before 55 days. We can shorten it, here to 45.

But I'm not sure why we don't just use `1` here instead, not sure it would do any harm to hit the API daily.

