### PR TITLE
fix(keepalive): Run keepalive step only for scheduled run

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -108,7 +108,7 @@ runs:
 
     # keepalive-workflow keeps GitHub from turning off tests after 60 days
     - uses: gautamkrishnar/keepalive-workflow@v2
-      if: always() && matrix.ddev_version == 'stable' && inputs.keepalive == 'true'
+      if: always() && matrix.ddev_version == 'stable' && inputs.keepalive == 'true' && github.event_name == 'schedule'
       with:
         time_elapsed: ${{ inputs.keepalive_time_elapsed }}
 


### PR DESCRIPTION
## The Issue

Fixes #32 

## How This PR Solves The Issue

Add a `github.event_name == 'schedule'` condition to run the keepalive step

## Manual Testing Instructions

I configured one of my repo to use this action with the specific PR commit: 
```
- uses: ddev/ddev-add-on-test@4158e3b82aec5b96930d7d87f3f848af3f02d06c
```

A push on this repo shows that keepalive step has not been triggered : 
https://github.com/julienloizelet/ddev-tools/actions/runs/9219045168/job/25363573618
 (at the end, there is no mention of the `gautamkrishnar/keepalive-workflow@v2` step
 
 A scheduled workflow triggered it: 
https://github.com/julienloizelet/ddev-tools/actions/runs/9219156058/job/25363832731
 
(at the end, we can see that the keepalive API call has been launched: `Kept repo active using the GitHUb API...`)
 

