### PR TITLE
feat(*): Add test_command input and exclude release tagged tests for pull request

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,18 @@
 # DDEV add-on test action
 
 ---
+
 > A GitHub action to run tests on a DDEV add-on.
+
 ---
 
 [![Version](https://img.shields.io/github/v/release/ddev/github-action-add-on-test)](https://github.com/ddev/github-action-add-on-test/releases)
 ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
 [![tests](https://github.com/ddev/github-action-add-on-test/actions/workflows/add-ons-test.yml/badge.svg)](https://github.com/ddev/github-action-add-on-test/actions/workflows/add-ons-test.yml)
 
-
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
 **Table of Contents**
 
 - [Quick start](#quick-start)
@@ -44,12 +46,12 @@ This step will install the latest stable version of DDEV and run `bats tests` co
 
 ## Inputs
 
-
 ### Available keys
 
 The following keys are available as `step.with` keys:
 
 ---
+
 - `ddev_version` (_String_)
 
 DDEV version that will be installed before your tests.
@@ -74,13 +76,12 @@ Example: `${{ secrets.GITHUB_TOKEN }}`.
 
 - `addon_repository`(_String_)
 
-GitHub repository of the tested addon (`{owner}/{repo}`). Will be used as the `repository` key during a [checkout 
+GitHub repository of the tested addon (`{owner}/{repo}`). Will be used as the `repository` key during a [checkout
 action](https://github.com/actions/checkout#usage)
 
 Required.
 
 Example: `${{ env.GITHUB_REPOSITORY }}`.
-
 
 ---
 
@@ -96,7 +97,7 @@ Example: `${{ env.GITHUB_REF }}`.
 
 - `addon_path`(_String_)
 
-Path (relative to `$GITHUB_WORKSPACE` ) where the addon will be cloned by a checkout action. Will be used as the `path` 
+Path (relative to `$GITHUB_WORKSPACE` ) where the addon will be cloned by a checkout action. Will be used as the `path`
 key of the [checkout action](https://github.com/actions/checkout#usage)
 
 Not required.
@@ -107,7 +108,7 @@ Default: `./`
 
 - `keepalive` (_Boolean_)
 
-Keeps GitHub from turning off tests after 60 days. 
+Keeps GitHub from turning off tests after 60 days.
 
 If enabled, action will use [keepalive-workflow action](https://github.com/gautamkrishnar/keepalive-workflow) when `ddev_version` has been set to `stable`.
 
@@ -124,19 +125,17 @@ Default: `true`.
 
 ---
 
-
 - `keepalive_time_elapsed` (_String_)
 
 Time elapsed from the previous commit to keep the repository active using GitHub API (in days).
 
-Will be used as the `time_elapsed` key of the  [keepalive-workflow action](https://github.com/gautamkrishnar/keepalive-workflow).
+Will be used as the `time_elapsed` key of the [keepalive-workflow action](https://github.com/gautamkrishnar/keepalive-workflow).
 
 Not required.
 
 Default: `"0"`.
 
 ---
-
 
 - `debug_enabled` (_Boolean_)
 
@@ -158,27 +157,38 @@ Default: `false`.
 
 ---
 
+- `test_command` (_String_)
+
+If you want to run a customized test command, you can use this input.
+
+If it's empty, the test command will be `bats tests --filter-tags !release` during a pull request workflow and `bats tests` otherwise.
+
+Not required.
+
+Default: `""`.
+
+---
+
 ## Usage
 
 ### Test your DDEV add-on
 
-If your add-on is based on the [DDEV add-on template repository](https://github.com/ddev/ddev-addon-template), you 
+If your add-on is based on the [DDEV add-on template repository](https://github.com/ddev/ddev-addon-template), you
 should have a tests folder containing a `test.bats` file.
 
-Using this GitHub action, a  `.github/workflows/tests.yml` file could have the following content: 
-
+Using this GitHub action, a `.github/workflows/tests.yml` file could have the following content:
 
 ```yaml
 name: tests
 on:
   pull_request:
   push:
-    branches: [ main ]
+    branches: [main]
     paths-ignore:
-      - '**.md'
+      - "**.md"
 
   schedule:
-  - cron: '25 08 * * *'
+    - cron: "25 08 * * *"
 
   workflow_dispatch:
     inputs:
@@ -192,7 +202,6 @@ permissions:
 
 jobs:
   tests:
-
     strategy:
       matrix:
         ddev_version: [stable, HEAD]
@@ -201,16 +210,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-
-    - uses: ddev/github-action-add-on-test@v2
-      with:
-        ddev_version: ${{ matrix.ddev_version }}
-        token: ${{ secrets.GITHUB_TOKEN }}
-        debug_enabled: ${{ github.event.inputs.debug_enabled }}
-        addon_repository: ${{ env.GITHUB_REPOSITORY }}
-        addon_ref: ${{ env.GITHUB_REF }}
+      - uses: ddev/github-action-add-on-test@v2
+        with:
+          ddev_version: ${{ matrix.ddev_version }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          debug_enabled: ${{ github.event.inputs.debug_enabled }}
+          addon_repository: ${{ env.GITHUB_REPOSITORY }}
+          addon_ref: ${{ env.GITHUB_REF }}
 ```
-
 
 ## License
 
@@ -219,6 +226,5 @@ jobs:
 ## Contribute
 
 Anyone is welcome to submit a pull request to this repository.
-
 
 **Contributed and maintained by [julienloizelet](https://github.com/julienloizelet)**

--- a/action.yaml
+++ b/action.yaml
@@ -3,7 +3,6 @@ author: "Julien Loizelet"
 description: "A Github Action to run DDEV add-on tests"
 
 inputs:
-
   ddev_version:
     type: choice
     required: false
@@ -14,49 +13,53 @@ inputs:
       - "HEAD"
 
   addon_repository:
-    description: 'Repository of the tested addon'
+    description: "Repository of the tested addon"
     required: true
 
   addon_ref:
-    description: 'Repository ref of the tested addon'
+    description: "Repository ref of the tested addon"
     required: true
 
   addon_path:
-    description: 'Path to clone the addon'
+    description: "Path to clone the addon"
     required: false
-    default: './'
+    default: "./"
 
   keepalive:
     type: boolean
-    description: 'Keeps GitHub from turning off tests after 60 days'
+    description: "Keeps GitHub from turning off tests after 60 days"
     required: false
     default: true
 
   keepalive_time_elapsed:
-    description: 'Time elapsed from the most recent commit to hit API and prevent expiration (in days)'
+    description: "Time elapsed from the most recent commit to hit API and prevent expiration (in days)"
     required: false
     default: "0"
 
   debug_enabled:
     type: boolean
-    description: Debug with tmate
+    description: "Debug with tmate"
     required: false
     default: false
 
   disable_checkout_action:
     type: boolean
-    description: Disable addon checkout action
+    description: "Disable addon checkout action"
     required: false
     default: false
 
   token:
-    description: 'A Github PAT'
+    description: "A Github PAT"
     required: true
+
+  test_command:
+    description: "Test command to run"
+    required: false
+    default: ""
 
 runs:
   using: "composite"
   steps:
-
     - uses: Homebrew/actions/setup-homebrew@master
 
     - name: Environment setup
@@ -102,9 +105,20 @@ runs:
         DDEV_NONINTERACTIVE: "true"
         # Don't send telemetry to amplitude
         DDEV_NO_INSTRUMENTATION: "true"
+        # Use test_command input if provided
+        TEST_COMMAND_INPUT: ${{ inputs.test_command }}
 
       shell: bash
-      run: cd ${{ inputs.addon_path }} && bats tests
+      run: |
+        if [ -n "$TEST_COMMAND_INPUT" ]; then
+          TEST_COMMAND="$TEST_COMMAND_INPUT"
+        elif [ "${{ github.event_name }}" == "pull_request" ]; then
+          TEST_COMMAND="bats tests --filter-tags !release"
+        else
+          TEST_COMMAND="bats tests"
+        fi
+        set +H
+        cd ${{ inputs.addon_path }} && $TEST_COMMAND
 
     # keepalive-workflow keeps GitHub from turning off tests after 60 days
     - uses: gautamkrishnar/keepalive-workflow@v2

--- a/action.yaml
+++ b/action.yaml
@@ -107,9 +107,12 @@ runs:
         DDEV_NO_INSTRUMENTATION: "true"
         # Use test_command input if provided
         TEST_COMMAND_INPUT: ${{ inputs.test_command }}
+        # Use the addon path
+        ADDON_PATH: ${{ inputs.addon_path }}
       shell: bash
-      # Using set +H to avoid history expansion in bash when using ! in test_command
+      # Use of "set +H" to ensure that bash history expansion is disabled so that ! can be used in test command
       run: |
+        set +H
         if [ -n "$TEST_COMMAND_INPUT" ]; then
           TEST_COMMAND="$TEST_COMMAND_INPUT"
         elif [ "${{ github.event_name }}" == "pull_request" ]; then
@@ -117,8 +120,8 @@ runs:
         else
           TEST_COMMAND="bats tests"
         fi
-        set +H
-        cd ${{ inputs.addon_path }} && $TEST_COMMAND
+        echo "Running: $TEST_COMMAND in $ADDON_PATH"
+        cd $ADDON_PATH && $TEST_COMMAND
 
     # keepalive-workflow keeps GitHub from turning off tests after 60 days
     - uses: gautamkrishnar/keepalive-workflow@v2

--- a/action.yaml
+++ b/action.yaml
@@ -107,8 +107,8 @@ runs:
         DDEV_NO_INSTRUMENTATION: "true"
         # Use test_command input if provided
         TEST_COMMAND_INPUT: ${{ inputs.test_command }}
-
       shell: bash
+      # Using set +H to avoid history expansion in bash when using ! in test_command
       run: |
         if [ -n "$TEST_COMMAND_INPUT" ]; then
           TEST_COMMAND="$TEST_COMMAND_INPUT"


### PR DESCRIPTION
## The Issue

Fixes #30 

## How This PR Solves The Issue

- By default, the test command launched on pull request workflow will be `bats tests --filter-tags !release`

With this, if the add-on test is tagged with the "release" tag, it won't be executed on pull request workflow: 

```
# bats test_tags=release
@test "install from release" {
...
...
}
```

- On other workflow ("schedule", "push", etc.), the test command will be, by default,  as before : `bats tests`

- If an add-on maintainer needs to pass a customized test command, there is a new available string input `test_command`.
When the `test_command` input is not empty, it will be used to run the test.


## Manual Testing Instructions

To test the final behavior, you can use my forked action and points to the last commit: 

```
steps:
      - uses: julienloizelet/ddev-add-on-test@b6b8c765ddba5fa511c2f9284e818d7fa3230f27
      with: 
          ...
```

### How to test

1) Backward compatibility : Create a pull request on your add-on: If you have no "release" tagged test, all test should be run as before

2) Exclude "release" test: Tag a test with the "release" tag. This test should not be executed on PR workflow.

3) Customized test_command: Use the `test_command` input to see if your customized test command is launched.

4) backward compatibility (hard to test: you can modify the tests.yml workflow to be triggered during a push on a testing branch that contains the new action). Ensure that the launched command, for a non pull request workflow, is as before (`bats tests`) and that all tests are runned.


