### PR TITLE
feat(*): Exclude release tagged tests for push workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Default: `false`.
 
 If you want to run a customized test command, you can use this input.
 
-If it's empty, the test command will be `bats tests --filter-tags !release` during a pull request workflow and `bats tests` otherwise.
+If it's empty, the test command will be `bats tests --filter-tags !release` during _push_ or _pull request_ workflows and `bats tests` otherwise.
 
 Not required.
 

--- a/action.yaml
+++ b/action.yaml
@@ -109,16 +109,23 @@ runs:
         TEST_COMMAND_INPUT: ${{ inputs.test_command }}
         # Use the addon path
         ADDON_PATH: ${{ inputs.addon_path }}
+        # Use the event name
+        GITHUB_EVENT_NAME: ${{ github.event_name }}
       shell: bash
       # Use of "set +H" to ensure that bash history expansion is disabled so that ! can be used in test command
       run: |
         set +H
         if [ -n "$TEST_COMMAND_INPUT" ]; then
           TEST_COMMAND="$TEST_COMMAND_INPUT"
-        elif [ "${{ github.event_name }}" == "pull_request" ]; then
-          TEST_COMMAND="bats tests --filter-tags !release"
         else
-          TEST_COMMAND="bats tests"
+          case "$GITHUB_EVENT_NAME" in
+            "push"|"pull_request")
+              TEST_COMMAND="bats tests --filter-tags !release"
+              ;;
+            *)
+              TEST_COMMAND="bats tests"
+              ;;
+          esac
         fi
         echo "Running: $TEST_COMMAND in $ADDON_PATH"
         cd $ADDON_PATH && $TEST_COMMAND


### PR DESCRIPTION
## The Issue

Following this: https://github.com/ddev/github-action-add-on-test/issues/37, we want to exclude release tagged tests for push workflow too.

## How This PR Solves The Issue

It excludes release tagged tests for push workflow.

## Manual Testing Instructions

`julienloizelet/ddev-add-on-test@20a7c1489181dae10ce6af9b0680899e2f33c8a2` can be used to test the code coming with this PR.

I've already tested that the result is as expected for 

- a [push workflow](https://github.com/julienloizelet/ddev-tools/actions/runs/11550603213)
- a [pull_request workflow](https://github.com/julienloizelet/ddev-tools/actions/runs/11550626525)
- [another workflow](https://github.com/julienloizelet/ddev-tools/actions/runs/11550631235) (workflow_dispatch in my test)

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

Fixes #37 

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

