### PR TITLE
docs: Minor documentation updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,16 @@ The [public API](https://semver.org/spec/v2.0.0.html#spec-item-1) of this projec
 
 ---
 
-## [v2.4.0](https://github.com/ddev/github-action-add-on-test/releases/tag/v2.4.0) - 2025-04-22
+## [v2.3.2](https://github.com/ddev/github-action-add-on-test/releases/tag/v2.4.0) - 2025-04-22
 
-[_Compare with previous release_](https://github.com/ddev/github-action-add-on-test/compare/v2.3.0...v2.4.0)
+[_Compare with previous release_](https://github.com/ddev/github-action-add-on-test/compare/v2.3.1...v2.3.2)
+
+### Minor Documentation updates
+
+
+## [v2.3.1](https://github.com/ddev/github-action-add-on-test/releases/tag/v2.4.0) - 2025-04-22
+
+[_Compare with previous release_](https://github.com/ddev/github-action-add-on-test/compare/v2.3.0...v2.3.1)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,14 @@ The [public API](https://semver.org/spec/v2.0.0.html#spec-item-1) of this projec
 
 ---
 
-## [v2.3.2](https://github.com/ddev/github-action-add-on-test/releases/tag/v2.4.0) - 2025-04-22
+## [v2.3.2](https://github.com/ddev/github-action-add-on-test/releases/tag/v2.3.2) - 2025-04-22
 
 [_Compare with previous release_](https://github.com/ddev/github-action-add-on-test/compare/v2.3.1...v2.3.2)
 
 ### Minor Documentation updates
 
 
-## [v2.3.1](https://github.com/ddev/github-action-add-on-test/releases/tag/v2.4.0) - 2025-04-22
+## [v2.3.1](https://github.com/ddev/github-action-add-on-test/releases/tag/v2.3.1) - 2025-04-22
 
 [_Compare with previous release_](https://github.com/ddev/github-action-add-on-test/compare/v2.3.0...v2.3.1)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ---
 
 [![Version](https://img.shields.io/github/v/release/ddev/github-action-add-on-test)](https://github.com/ddev/github-action-add-on-test/releases)
-![project is maintained](https://img.shields.io/maintenance/yes/2025.svg)
+[![last commit](https://img.shields.io/github/last-commit/ddev/github-action-add-on-test)](https://github.com/ddev/github-action-add-on-test/commits)
 [![tests](https://github.com/ddev/github-action-add-on-test/actions/workflows/add-ons-test.yml/badge.svg)](https://github.com/ddev/github-action-add-on-test/actions/workflows/add-ons-test.yml)
 
 **Table of Contents**

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -78,7 +78,7 @@ Before publishing a new release, there are some manual steps to take:
 - Update the `CHANGELOG.md` file to the current format. The release description is based on the contents of the `CHANGELOG.md` file.
 - If the release is a major release, modify the major tag in the `README.md` file wherever necessary.
 
-Then, you have to [run the action manually from the GitHub repository](https://github.com/ddev/github-action-add-on-test/actions/workflows/release.yml)
+Then, you have to [run the action manually using `Actions -> Create Release -> Tag Name`](https://github.com/ddev/github-action-add-on-test/actions/workflows/release.yml). 
 
 Alternatively, you could use the [GitHub CLI](https://github.com/cli/cli):
 


### PR DESCRIPTION
## The Issue

* Minor docs updates
* When I created v2.3.1 today I didn't use the proper technique, so the v2 tag did not get moved

When this goes in, I'll create v2.3.2 and we'll see if it works right.

