### PR TITLE
build: use main branch for setup-homebrew

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -49,7 +49,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: Homebrew/actions/setup-homebrew@master
+    - uses: Homebrew/actions/setup-homebrew@main
 
     - name: Environment setup
       shell: bash


### PR DESCRIPTION
## The Issue

The homebrew folks changed the default branch for the setup-homebrew action (and others) to `main` from `master`

https://github.com/Homebrew/actions

## How This PR Solves The Issue

Use the new branch.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

