### PR TITLE
build: Use official brew tap for bats-core

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -55,7 +55,7 @@ runs:
       shell: bash
       run: |
         # For bats-assert and friends
-        brew tap kaos/shell >/dev/null
+        brew tap bats-core/bats-core >/dev/null
         brew install bats-core bats-file bats-assert bats-support jq mkcert yq >/dev/null
         mkcert -install
 


### PR DESCRIPTION
## The Issue

We're seeing some failures like https://github.com/ddev/github-action-add-on-test/actions/runs/15903599363 in tests

> Cloning into '/home/linuxbrew/.linuxbrew/Homebrew/Library/Taps/kaos/homebrew-shell'...
Tapped 7 formulae (25 files, 141.7KB).
> Error: Formula installation already attempted: kaos/shell/bats-support


## How This PR Solves The Issue

Try using the official homebrew tap instead of kaos

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

