### PR TITLE
chore(release): add template for PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## The Issue
+
+- Fixes #REPLACE_ME_WITH_RELATED_ISSUE_NUMBER
+
+<!-- Provide a brief description of the issue. -->
+
+## How This PR Solves The Issue
+
+<!-- Describe the key change(s) in this PR that address the issue above. -->
+
+## Manual Testing Instructions
+
+<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->
+
+## Automated Testing Overview
+
+<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->
+
+## Release/Deployment Notes
+
+Don't create releases manually. Follow the [release process documentation](https://github.com/ddev/github-action-add-on-test/blob/main/docs/DEVELOPER.md#release-process) when making a new release.
+
+<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->


### PR DESCRIPTION
## The Issue

We don't remember that releases here need to be done with https://github.com/ddev/github-action-add-on-test/actions/workflows/release.yml

As a result, releases created with the GUI do not update the 'v2' tag, and we wonder why this action doesn't work.

## How This PR Solves The Issue

Adds info about it into this PR template.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

Don't create releases manually. Follow the [release process documentation](https://github.com/ddev/github-action-add-on-test/blob/main/docs/DEVELOPER.md#release-process) when making a new release.
