### PR TITLE
feat: add ISSUE templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,45 @@
+name: 🐞 Bug report or Support Request
+description: Create a report to help us improve.
+labels: [bug]
+body:
+  - type: checkboxes
+    attributes:
+      label: Preliminary checklist
+      description: Please complete the following checks before submitting an issue.
+      options:
+        - label: I am using the latest stable version of DDEV
+          required: true
+        - label: I am using the latest stable version of this action
+          required: true
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Actual Behavior
+      description: What actually happened instead?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Steps To Reproduce
+      description: Specific steps to reproduce the behavior.
+      placeholder: |
+        1. In this environment...
+        2. With this config...
+        3. Run `...`
+        4. See error...
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Anything else?
+      description: |
+        Links? References? Screenshots? Anything that will give us more context about your issue!
+
+        💡 Attach images or log files by clicking this area to highlight it and dragging files in.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,35 @@
+name: 🚀 Feature request
+description: Suggest an idea for this project.
+labels: [enhancement]
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search existing issues to see if one already exists for your request.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: textarea
+    attributes:
+      label: Is your feature request related to a problem?
+      description: Clearly and concisely describe the problem. (Ex. I'm always frustrated when...)
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe your solution
+      description: Clearly and concisely describe what you want to happen.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Describe alternatives
+      description: Clearly and concisely describe any alternative solutions or features you've considered.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request.
+    validations:
+      required: false


### PR DESCRIPTION
## The Issue

We have a PR template but no issue templates, which are standard across our other DDEV repositories.

## How This PR Solves The Issue

This PR adds the following templates:

- Bug report
- Feature request

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

