### PR TITLE
chore: bump Homebrew/actions/setup-homebrew, fixes #58

### DIFF
--- a/.github/workflows/doc-links.yml
+++ b/.github/workflows/doc-links.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  
 permissions:
   contents: read
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ The [public API](https://semver.org/spec/v2.0.0.html#spec-item-1) of this projec
 
 ---
 
+## [v2.4.2](https://github.com/ddev/github-action-add-on-test/releases/tag/v2.4.2) - 2026-03-12
+
+[_Compare with previous release_](https://github.com/ddev/github-action-add-on-test/compare/v2.4.1...v2.4.2)
+
+### Changed
+
+- Bump Homebrew/actions/setup-homebrew ([PR #60](https://github.com/ddev/github-action-add-on-test/pull/60))
+
+---
+
+---
+
 ## [v2.4.1](https://github.com/ddev/github-action-add-on-test/releases/tag/v2.4.1) - 2026-03-12
 
 [_Compare with previous release_](https://github.com/ddev/github-action-add-on-test/compare/v2.4.0...v2.4.1)

--- a/action.yaml
+++ b/action.yaml
@@ -2,6 +2,10 @@ name: "DDEV add-on test"
 author: "Julien Loizelet"
 description: "A Github Action to run DDEV add-on tests"
 
+env:
+  # Work around homebrew install trying to use deprecated node 20
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 inputs:
   ddev_version:
     type: choice

--- a/action.yaml
+++ b/action.yaml
@@ -2,10 +2,6 @@ name: "DDEV add-on test"
 author: "Julien Loizelet"
 description: "A Github Action to run DDEV add-on tests"
 
-env:
-  # Work around homebrew install trying to use deprecated node 20
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
-
 inputs:
   ddev_version:
     type: choice
@@ -53,7 +49,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: Homebrew/actions/setup-homebrew@4cdec6dc3e14702214632b392c91a7cc283fbc8a #no release tags available
+    - uses: Homebrew/actions/setup-homebrew@675fcd27b59e54d310c5484c8c27c01d03da660c #no release tags available
 
     - name: Environment setup
       shell: bash


### PR DESCRIPTION
## The Issue

- Fixes #58

* Node 20 is deprecated, but the homebrew installer tries to use it, so all add-ons have warnings.
* First run of the test failed markdown link tests, so I added the GItHUB_TOKEN env to try to solve it.
