### PR TITLE
ci: prevent deadlock for reusable test workflow

### DIFF
--- a/.github/workflows/add-ons-test.yml
+++ b/.github/workflows/add-ons-test.yml
@@ -26,7 +26,7 @@ on:
         default: ""
 
 concurrency:
-  group: add-ons-test-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.action_ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/add-ons-test.yml
+++ b/.github/workflows/add-ons-test.yml
@@ -26,7 +26,7 @@ on:
         default: ""
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: add-ons-test-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## The Issue

https://github.com/ddev/github-action-add-on-test/actions/runs/27135026446

```
Create Release
Canceling since a deadlock was detected for concurrency group: 'Create Release-refs/heads/main' between a top level workflow and 'Run test on add-ons'
```

## How This PR Solves The Issue

Uses a unique name for `add-ons-test.yml`

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

Don't create releases manually. Follow the [release process documentation](https://github.com/ddev/github-action-add-on-test/blob/main/docs/DEVELOPER.md#release-process) when making a new release.

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
