### PR TITLE
ci(homebrew): add HOMEBREW_NO_SANDBOX_LINUX=1 (temporary fix)

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -49,7 +49,11 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: Homebrew/actions/setup-homebrew@f830e99d47c69efee99f1ddbf18a8e3144d1b93e # https://github.com/Homebrew/actions/commits/main/setup-homebrew/ test
+    - name: Set Homebrew env
+      shell: bash
+      run: echo "HOMEBREW_NO_SANDBOX_LINUX=1" >> $GITHUB_ENV
+
+    - uses: Homebrew/actions/setup-homebrew@f830e99d47c69efee99f1ddbf18a8e3144d1b93e # https://github.com/Homebrew/actions/commits/main/setup-homebrew/
 
     - name: Environment setup
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -49,7 +49,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: Homebrew/actions/setup-homebrew@f830e99d47c69efee99f1ddbf18a8e3144d1b93e # https://github.com/Homebrew/actions/commits/main/setup-homebrew/
+    - uses: Homebrew/actions/setup-homebrew@f830e99d47c69efee99f1ddbf18a8e3144d1b93e # https://github.com/Homebrew/actions/commits/main/setup-homebrew/ test
 
     - name: Environment setup
       shell: bash


### PR DESCRIPTION
## The Issue

- https://github.com/Homebrew/actions/issues/865

Changes in Homebrew 6.0.0 and `Homebrew/actions/setup-homebrew` is not updated for this.

https://github.com/ddev/github-action-add-on-test/actions/runs/27355373227/job/80828105647?pr=64

```
Error: Bubblewrap is installed but cannot create a rootless sandbox.

Homebrew's Linux sandbox requires rootless Bubblewrap and unprivileged
user namespaces. Check and update this system configuration:
  sudo sysctl -w kernel.unprivileged_userns_clone=1
    Allows unprivileged processes to create user namespaces. Rootless
    Bubblewrap needs this to isolate builds without elevated privileges.
  sudo sysctl -w user.max_user_namespaces=28633
    Allows each user to allocate enough user namespaces. A zero or low
    limit can prevent Bubblewrap from creating its sandbox.
  sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
    Allows unprivileged user namespaces on AppArmor-enabled systems
    that restrict them by default. Older kernels may not provide this
    setting.

As a final workaround, disable the Linux sandbox:
  export HOMEBREW_NO_SANDBOX_LINUX=1
```

## How This PR Solves The Issue

Adds `HOMEBREW_NO_SANDBOX_LINUX=1`, I'm going to remove it once the upstream is updated.

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

Don't create releases manually. Follow the [release process documentation](https://github.com/ddev/github-action-add-on-test/blob/main/docs/DEVELOPER.md#release-process) when making a new release.

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
