### PR TITLE
ci(homebrew): add setup-sandbox and trust, for #64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ The [public API](https://semver.org/spec/v2.0.0.html#spec-item-1) of this projec
 
 ---
 
+## [v2.4.5](https://github.com/ddev/github-action-add-on-test/releases/tag/v2.4.5) - 2026-06-15
+
+[_Compare with previous release_](https://github.com/ddev/github-action-add-on-test/compare/v2.4.4...v2.4.5)
+
+### Changed
+
+- Use `setup-sandbox: true` in Homebrew ([PR #66](https://github.com/ddev/github-action-add-on-test/pull/66))
+
+---
+
 ## [v2.4.4](https://github.com/ddev/github-action-add-on-test/releases/tag/v2.4.4) - 2026-06-11
 
 [_Compare with previous release_](https://github.com/ddev/github-action-add-on-test/compare/v2.4.3...v2.4.4)

--- a/action.yaml
+++ b/action.yaml
@@ -49,16 +49,14 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set Homebrew env
-      shell: bash
-      run: echo "HOMEBREW_NO_SANDBOX_LINUX=1" >> $GITHUB_ENV
-
     - uses: Homebrew/actions/setup-homebrew@f830e99d47c69efee99f1ddbf18a8e3144d1b93e # https://github.com/Homebrew/actions/commits/main/setup-homebrew/
 
     - name: Environment setup
       shell: bash
       run: |
-        brew install bats-core bats-core/bats-core/bats-assert bats-core/bats-core/bats-file bats-core/bats-core/bats-support jq mkcert yq >/dev/null
+        brew tap bats-core/bats-core
+        brew trust bats-core/bats-core
+        brew install bats-core bats-assert bats-file bats-support jq mkcert yq >/dev/null
         mkcert -install
 
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # https://github.com/actions/checkout/commits/v6.0.3/

--- a/action.yaml
+++ b/action.yaml
@@ -49,14 +49,15 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: Homebrew/actions/setup-homebrew@f830e99d47c69efee99f1ddbf18a8e3144d1b93e # https://github.com/Homebrew/actions/commits/main/setup-homebrew/
+    - uses: Homebrew/actions/setup-homebrew@54f3c3de99e48b2646ca31230c9b6e9717dac4d4 # https://github.com/Homebrew/actions/commits/main/setup-homebrew/
+      with:
+        setup-sandbox: true
 
     - name: Environment setup
       shell: bash
       run: |
-        brew tap bats-core/bats-core
         brew trust bats-core/bats-core
-        brew install bats-core bats-assert bats-file bats-support jq mkcert yq >/dev/null
+        brew install bats-core bats-core/bats-core/bats-assert bats-core/bats-core/bats-file bats-core/bats-core/bats-support jq mkcert yq >/dev/null
         mkcert -install
 
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # https://github.com/actions/checkout/commits/v6.0.3/
@@ -69,12 +70,16 @@ runs:
     - name: Use ddev stable
       shell: bash
       if: inputs.ddev_version == 'stable'
-      run: brew install ddev/ddev/ddev >/dev/null
+      run: |
+        brew trust ddev/ddev
+        brew install ddev/ddev/ddev >/dev/null
 
     - name: Use ddev HEAD
       shell: bash
       if: inputs.ddev_version == 'HEAD'
-      run: brew install --HEAD ddev/ddev/ddev >/dev/null
+      run: |
+        brew trust ddev/ddev
+        brew install --HEAD ddev/ddev/ddev >/dev/null
 
     - name: Download docker images
       shell: bash


### PR DESCRIPTION
## The Issue

- For #64

<!-- Provide a brief description of the issue. -->

## How This PR Solves The Issue

- Adds `setup-sandbox: true`
- Adds `brew trust` to avoid warnings for taps

## Manual Testing Instructions

<!-- If this PR changes logic, consider adding additional steps or context to the instructions below. -->

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

Don't create releases manually. Follow the [release process documentation](https://github.com/ddev/github-action-add-on-test/blob/main/docs/DEVELOPER.md#release-process) when making a new release.

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
